### PR TITLE
Update model.py

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -103,8 +103,10 @@ class PlantsDiseaseDataset(Dataset):
                     img_fp = os.path.join(VAL_IMG_PATH,
                                           _['image_id']).encode('ascii', 'ignore').decode('utf-8')
                     if os.path.exists(img_fp):
-                        imgs.append(img_fp)
-                        lbs.append(_['disease_class'])
+                        label_to_match = _['disease_class']
+                        if label_to_match in MAP_61to45.keys():
+                            imgs.append(img_fp)
+                            lbs.append(_['disease_class'])
             sub_lbs = []
             for idx in range(len(lbs)):
                 if str(lbs[idx]) in MAP_61to45.keys():

--- a/model.py
+++ b/model.py
@@ -40,9 +40,9 @@ class BasicCNN(nn.Module):
         x = self.Layer3(x)
         x = self.relu4(x)
 
-        x1 = F.softmax(self.FC1(x.view(-1, 244*244*64)), dim=1)
-        x2 = F.softmax(self.FC2(x.view(-1, 244*244*64)), dim=1)
-        x3 = F.softmax(self.FC3(x.view(-1, 244*244*64)), dim=1)
+        x1 = self.FC1(x.view(-1, 244*244*64))
+        x2 = self.FC2(x.view(-1, 244*244*64))
+        x3 = self.FC3(x.view(-1, 244*244*64))
 
         return x1, x2, x3
 
@@ -85,7 +85,7 @@ class DiseaseModel(nn.Module):
         x = self.Layer2(x)
         x = self.Layer3(x)
         x = self.Shuffle2_3(self.Shuffle2_2(self.Shuffle2_1(x)))
-        x = F.softmax(self.FC(x.view(-1, 2048*4*4)), dim=1)
+        x = self.FC(x.view(-1, 2048*4*4))
         return x
 
 
@@ -117,7 +117,7 @@ class PlantModel(nn.Module):
         x = self.Layer2(x)
         x = self.Layer3(x)
         x = self.Shuffle1_3(self.Shuffle1_2(self.Shuffle1_1(x)))
-        x = F.softmax(self.FC(x.view(-1, 2048*8*8)), dim=1)
+        x = self.FC(x.view(-1, 2048*8*8))
         return x
 
 
@@ -159,7 +159,7 @@ class PD2SEModel(nn.Module):
         severity_class = severity_class.view(-1, 2048*8*8)
         plant_class = plant_class.view(-1, 2048*8*8)
         disease_class = disease_class.view(-1, 2048*4*4)
-        plant_class = F.softmax(self.FC1(plant_class), dim=1)
-        disease_class = F.softmax(self.FC2(disease_class), dim=1)
-        severity_class = F.softmax(self.FC3(severity_class), dim=1)
+        plant_class =self.FC1(plant_class)
+        disease_class = self.FC2(disease_class)
+        severity_class = self.FC3(severity_class)
         return plant_class, disease_class, severity_class


### PR DESCRIPTION
For model.py:
If you use the `nn.CrossEntropyLoss()` to compute the loss, you shouldn't  use `softmax` before computing loss. Because `nn.CrossEntropyLoss()` include the softmax step. It is clearly that it would be wrong to use the softmax steps twice.

For dataset.py:
I find that the number of test image and label is not equal. So I checked out the code and found the bug.